### PR TITLE
Enable meson install for executable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,5 +13,5 @@ fs.copyfile('LICENSE', 'LICENSE')
 fs.copyfile('THIRD_PARTY_LICENSES', 'THIRD_PARTY_LICENSES')
 
 libwebsocketsdep = dependency('libwebsockets')
-executable('tshotkeytrigger', ['main.c', 'datafile.c'], dependencies: [libwebsocketsdep])
+executable('tshotkeytrigger', ['main.c', 'datafile.c'], dependencies: [libwebsocketsdep], install: true)
 


### PR DESCRIPTION
Enable the automatic installation by meson for ease of use. Meson will choose the appropriate install location automatically to put the binary into, e.g. `/usr/local/bin`.